### PR TITLE
GUACAMOLE-925: Add Russian keymap support "ru-ru-qwerty"

### DIFF
--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
@@ -123,6 +123,7 @@
                         "pt-br-qwerty",
                         "pt-pt-qwerty",
                         "ro-ro-qwerty",
+                        "ru-ru-qwerty",
                         "sv-se-qwerty",
                         "da-dk-qwerty",
                         "tr-tr-qwerty"

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -704,6 +704,7 @@
         "FIELD_OPTION_SERVER_LAYOUT_PT_BR_QWERTY" : "Portuguese Brazilian (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_PT_PT_QWERTY" : "Portuguese (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_RO_RO_QWERTY" : "Romanian (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_RU_RU_QWERTY" : "Russian (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_SV_SE_QWERTY" : "Swedish (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_TR_TR_QWERTY" : "Turkish-Q (Qwerty)",
 


### PR DESCRIPTION
The parameter "ru-ru-qwerty" has been added to the "guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json" file to support the Russian keyboard layout.
The parameter "FIELD_OPTION_SERVER_LAYOUT_RU_RU_QWERTY" : "Russian (Qwerty)" has been added to the "guacamole/src/main/frontend/src/translations/en.json" file to support the Russian keyboard layout.